### PR TITLE
style: レイアウトの修正

### DIFF
--- a/app/views/diagnoses/new.html.erb
+++ b/app/views/diagnoses/new.html.erb
@@ -26,19 +26,19 @@
         <div class="label-text mb-3 font-bold md:text-xl">
         第1問：会議が始まった直後、あなたが取る行動は？
         </div>
-        <label class="label cursor-pointer flex flex-wrap items-center space-x-3 text-neutral py-1 md:hover:bg-neutral-content">
+        <label class="label cursor-pointer flex items-center space-x-3 text-neutral py-1 md:hover:bg-neutral-content">
           <%= radio_button_tag "answers[question1]", "sleepiness:20,nod:5",
             @selected_answers&.dig("question1") == "sleepiness:20,nod:5",
             class: "radio radio-secondary radio-sm" %>
           <span>画面の明るさを落として目を休める</span>
         </label>
-        <label class="label cursor-pointer flex flex-wrap items-center space-x-3 text-neutral py-1 md:hover:bg-neutral-content">
+        <label class="label cursor-pointer flex items-center space-x-3 text-neutral py-1 md:hover:bg-neutral-content">
           <%= radio_button_tag "answers[question1]", "sharpness:25",
             @selected_answers&.dig("question1") == "sharpness:25",
             class: "radio radio-secondary radio-sm" %>
           <span>メモアプリを開き、構える</span>
         </label>
-        <label class="label cursor-pointer flex flex-wrap items-center space-x-3 text-neutral py-1 md:hover:bg-neutral-content">
+        <label class="label cursor-pointer flex items-center space-x-3 text-neutral py-1 md:hover:bg-neutral-content">
           <%= radio_button_tag "answers[question1]", "stealth:15,fade:10",
             @selected_answers&.dig("question1") == "stealth:15,fade:10",
             class: "radio radio-secondary radio-sm" %>
@@ -50,19 +50,19 @@
         <div class="label-text mb-3 font-bold md:text-xl">
         第2問：話題が明らかに脱線し始めた…あなたはどうする？
         </div>
-        <label class="label cursor-pointer flex flex-wrap items-center space-x-3 text-neutral py-1 md:hover:bg-neutral-content">
+        <label class="label cursor-pointer flex items-center space-x-3 text-neutral py-1 md:hover:bg-neutral-content">
           <%= radio_button_tag "answers[question2]", "sleepiness:25",
             @selected_answers&.dig("question2") == "sleepiness:25",
             class: "radio radio-secondary radio-sm" %>
           <span>その隙にウトウトしはじめる</span>
         </label>
-        <label class="label cursor-pointer flex flex-wrap items-center space-x-3 text-neutral py-1 md:hover:bg-neutral-content">
+        <label class="label cursor-pointer flex items-center space-x-3 text-neutral py-1 md:hover:bg-neutral-content">
           <%= radio_button_tag "answers[question2]", "sharpness:15,fade:10",
             @selected_answers&.dig("question2") == "sharpness:15,fade:10",
             class: "radio radio-secondary radio-sm" %>
           <span>「ちょっと気になったんですが…」と、さらに脱線を深める話題を放り込む</span>
         </label>
-        <label class="label cursor-pointer flex flex-wrap items-center space-x-3 text-neutral py-1 md:hover:bg-neutral-content">
+        <label class="label cursor-pointer flex items-center space-x-3 text-neutral py-1 md:hover:bg-neutral-content">
           <%= radio_button_tag "answers[question2]", "nod:15,stealth:10",
             @selected_answers&.dig("question2") == "nod:15,stealth:10",
             class: "radio radio-secondary radio-sm" %>
@@ -72,19 +72,19 @@
 
       <div class="w-full max-w-md mx-auto p-6 md:max-w-none md:mx-0">
         <div class="label-text mb-3 font-bold md:text-xl">第3問：「◯◯さんどう思います？」と急に振られた！</div>
-        <label class="label cursor-pointer flex flex-wrap items-center space-x-3 text-neutral py-1 md:hover:bg-neutral-content">
+        <label class="label cursor-pointer flex items-center space-x-3 text-neutral py-1 md:hover:bg-neutral-content">
           <%= radio_button_tag "answers[question3]", "nod:15,stealth:10",
             @selected_answers&.dig("question3") == "nod:15,stealth:10",
             class: "radio radio-secondary  radio-sm" %>
           <span> 急に咳き込むフリで時間を稼ぐ</span>
         </label>
-        <label class="label cursor-pointer flex flex-wrap items-center space-x-3 text-neutral py-1 md:hover:bg-neutral-content">
+        <label class="label cursor-pointer flex items-center space-x-3 text-neutral py-1 md:hover:bg-neutral-content">
           <%= radio_button_tag "answers[question3]", "sleepiness:5,stealth:20",
             @selected_answers&.dig("question3") == "sleepiness:5,stealth:20",
             class: "radio radio-secondary radio-sm" %>
           <span>「ちょうど資料探してて…」と画面共有で逃げる</span>
         </label>
-        <label class="label cursor-pointer flex flex-wrap items-center space-x-3 text-neutral py-1 md:hover:bg-neutral-content">
+        <label class="label cursor-pointer flex items-center space-x-3 text-neutral py-1 md:hover:bg-neutral-content">
           <%= radio_button_tag "answers[question3]", "sharpness:5,fade:20",
             @selected_answers&.dig("question3") == "sharpness:5,fade:20",
             class: "radio radio-secondary radio-sm" %>
@@ -94,19 +94,19 @@
 
       <div class="w-full max-w-md mx-auto p-6 md:max-w-none md:mx-0">
         <div class="label-text mb-3 font-bold md:text-xl">第4問：会議の終わりが見えない。あなたの心の声は？</div>
-        <label class="label cursor-pointer flex flex-wrap items-center space-x-3 text-neutral py-1 md:hover:bg-neutral-content">
+        <label class="label cursor-pointer flex items-center space-x-3 text-neutral py-1 md:hover:bg-neutral-content">
           <%= radio_button_tag "answers[question4]", "stealth:25",
             @selected_answers&.dig("question4") == "stealth:25",
             class: "radio radio-secondary radio-sm" %>
           <span>「議事録、もはや短歌でまとめた方が早くない？」</span>
         </label>
-        <label class="label cursor-pointer flex flex-wrap items-center space-x-3 text-neutral py-1 md:hover:bg-neutral-content">
+        <label class="label cursor-pointer flex items-center space-x-3 text-neutral py-1 md:hover:bg-neutral-content">
           <%= radio_button_tag "answers[question4]", "fade:20,sharpness:5",
             @selected_answers&.dig("question4") == "fade:20,sharpness:5",
             class: "radio radio-secondary radio-sm" %>
           <span>「この議題、あと7周くらい回す気か…？」</span>
         </label>
-        <label class="label cursor-pointer flex flex-wrap items-center space-x-3 text-neutral py-1 md:hover:bg-neutral-content">
+        <label class="label cursor-pointer flex items-center space-x-3 text-neutral py-1 md:hover:bg-neutral-content">
           <%= radio_button_tag "answers[question4]", "sleepiness:20,nod:5",
             @selected_answers&.dig("question4") == "sleepiness:20,nod:5",
             class: "radio radio-secondary radio-sm" %>
@@ -116,19 +116,19 @@
 
      <div class="w-full max-w-md mx-auto p-6 md:max-w-none md:mx-0">
         <div class="label-text mb-3 font-bold md:text-xl">第5問：会議のチャット欄、どう使ってる？</div>
-        <label class="label cursor-pointer flex flex-wrap items-center space-x-3 text-neutral py-1 md:hover:bg-neutral-content">
+        <label class="label cursor-pointer flex items-center space-x-3 text-neutral py-1 md:hover:bg-neutral-content">
           <%= radio_button_tag "answers[question5]", "fade:25",
           @selected_answers&.dig("question5") == "fade:25",
             class: "radio radio-secondary radio-sm" %>
           <span> 言いたいことはあるけど、なかなか送信ボタンが押せない</span>
         </label>
-        <label class="label cursor-pointer flex flex-wrap items-center space-x-3 text-neutral py-1 md:hover:bg-neutral-content">
+        <label class="label cursor-pointer flex items-center space-x-3 text-neutral py-1 md:hover:bg-neutral-content">
           <%= radio_button_tag "answers[question5]", "nod:15,stealth:10",
           @selected_answers&.dig("question5") == "nod:15,stealth:10",
           class: "radio radio-secondary radio-sm" %>
           <span>「承知しました（Ctrl+C）」→ Ctrl+V連打で“在席感”キープ</span>
         </label>
-        <label class="label cursor-pointer flex flex-wrap items-center space-x-3 text-neutral py-1 md:hover:bg-neutral-content">
+        <label class="label cursor-pointer flex items-center space-x-3 text-neutral py-1 md:hover:bg-neutral-content">
           <%= radio_button_tag "answers[question5]", "sharpness:15,sleepiness:10",
           @selected_answers&.dig("question5") == "sharpness:15,sleepiness:10",
             class: "radio radio-secondary radio-sm" %>
@@ -138,19 +138,19 @@
 
       <div class="w-full max-w-md mx-auto p-6 md:max-w-none md:mx-0">
         <div class="label-text mb-3 font-bold md:text-xl">第6問：会議が終わりそう。でも結論が出てない！</div>
-        <label class="label cursor-pointer flex flex-wrap items-center space-x-3 text-neutral py-1 md:hover:bg-neutral-content">
+        <label class="label cursor-pointer flex items-center space-x-3 text-neutral py-1 md:hover:bg-neutral-content">
           <%= radio_button_tag "answers[question6]", "sharpness:20,nod:5",
           @selected_answers&.dig("question6") == "sharpness:20,nod:5",
             class: "radio radio-secondary radio-sm" %>
           <span>「みんなで考えていきましょう！」と丸める</span>
         </label>
-        <label class="label cursor-pointer flex flex-wrap items-center space-x-3 text-neutral py-1 md:hover:bg-neutral-content">
+        <label class="label cursor-pointer flex items-center space-x-3 text-neutral py-1 md:hover:bg-neutral-content">
           <%= radio_button_tag "answers[question6]", "sleepiness:20,stealth:5",
           @selected_answers&.dig("question6") == "sleepiness:20,stealth:5",
           class: "radio radio-secondary radio-sm" %>
           <span> 最後の5分でなぜか覚醒</span>
         </label>
-        <label class="label cursor-pointer flex flex-wrap items-center space-x-3 text-neutral py-1 md:hover:bg-neutral-content">
+        <label class="label cursor-pointer flex items-center space-x-3 text-neutral py-1 md:hover:bg-neutral-content">
           <%= radio_button_tag "answers[question6]", "fade:20",
           @selected_answers&.dig("question6") == "fade:20",
             class: "radio radio-secondary radio-sm" %>
@@ -160,19 +160,19 @@
 
       <div class="w-full max-w-md mx-auto p-6 md:max-w-none md:mx-0">
         <div class="label-text mb-3 font-bold md:text-xl">第7問：今日はもう4本目の会議。あなたのテンションは？</div>
-        <label class="label cursor-pointer flex flex-wrap items-center space-x-3 text-neutral py-1 md:hover:bg-neutral-content">
+        <label class="label cursor-pointer flex items-center space-x-3 text-neutral py-1 md:hover:bg-neutral-content">
           <%= radio_button_tag "answers[question7]", "sleepiness:25",
           @selected_answers&.dig("question7") == "sleepiness:25",
             class: "radio radio-secondary radio-sm" %>
           <span>完全にエンジン切れ。夢と現実を彷徨う</span>
         </label>
-        <label class="label cursor-pointer flex flex-wrap items-center space-x-3 text-neutral py-1 md:hover:bg-neutral-content">
+        <label class="label cursor-pointer flex items-center space-x-3 text-neutral py-1 md:hover:bg-neutral-content">
           <%= radio_button_tag "answers[question7]", "sharpness:10",
           @selected_answers&.dig("question7") == "sharpness:10",
           class: "radio radio-secondary radio-sm" %>
           <span>逆にテンションが上がって意見言いまくる</span>
         </label>
-        <label class="label cursor-pointer flex flex-wrap items-center space-x-3 text-neutral py-1 md:hover:bg-neutral-content">
+        <label class="label cursor-pointer flex items-center space-x-3 text-neutral py-1 md:hover:bg-neutral-content">
           <%= radio_button_tag "answers[question7]", "stealth:5,nod:15",
           @selected_answers&.dig("question7") == "stealth:5,nod:15",
             class: "radio radio-secondary radio-sm" %>
@@ -182,19 +182,19 @@
 
       <div class="w-full max-w-md mx-auto p-6 md:max-w-none md:mx-0">
         <div class="label-text mb-3 font-bold md:text-xl">第8問：会議に「参加してた感」を残したい…何する？</div>
-        <label class="label cursor-pointer flex flex-wrap items-center space-x-3 text-neutral py-1 md:hover:bg-neutral-content">
+        <label class="label cursor-pointer flex items-center space-x-3 text-neutral py-1 md:hover:bg-neutral-content">
           <%= radio_button_tag "answers[question8]", "nod:15,stealth:10",
           @selected_answers&.dig("question8") == "nod:15,stealth:10",
             class: "radio radio-secondary radio-sm" %>
           <span>最後に「ありがとうございました！」とコメント</span>
         </label>
-        <label class="label cursor-pointer flexflex-wrap items-center space-x-3 text-neutral py-1 md:hover:bg-neutral-content">
+        <label class="label cursor-pointer flex items-center space-x-3 text-neutral py-1 md:hover:bg-neutral-content">
           <%= radio_button_tag "answers[question8]", "stealth:15,sleepiness:10",
           @selected_answers&.dig("question8") == "stealth:15,sleepiness:10",
           class: "radio radio-secondary radio-sm" %>
           <span>終了2分前にだけ一生懸命メモを取る仕草をする</span>
         </label>
-        <label class="label cursor-pointer flex flex-wrap items-center space-x-3 text-neutral py-1 md:hover:bg-neutral-content">
+        <label class="label cursor-pointer flex items-center space-x-3 text-neutral py-1 md:hover:bg-neutral-content">
           <%= radio_button_tag "answers[question8]", "fade:20",
           @selected_answers&.dig("question8") == "fade:20",
             class: "radio radio-secondary radio-sm" %>


### PR DESCRIPTION
`flex-wrap`を削除することで、文字の折り返しを無くしました。